### PR TITLE
Reserve the Create shadow volume sampler in Iris

### DIFF
--- a/src/main/java/top/leonx/irisflw/mixin/MixinProgramSamplers.java
+++ b/src/main/java/top/leonx/irisflw/mixin/MixinProgramSamplers.java
@@ -1,0 +1,22 @@
+package top.leonx.irisflw.mixin;
+
+import net.coderbot.iris.gl.program.ProgramSamplers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.At;
+import java.util.Set;
+import java.util.HashSet;
+
+@Mixin(value = ProgramSamplers.class,remap = false)
+public class MixinProgramSamplers {
+    @ModifyVariable(method = "builder", at = @At("LOAD"), argsOnly = true)
+    private static Set<Integer> modifyReservedTextureUnits(Set<Integer> var1) {
+        // Add the lighting volume texture from Create to the reserved textures.
+        //
+        // The set from Iris is immutable, so duplicate before modifying.
+        Set<Integer> reservedTextureUnits = new HashSet<Integer>();
+        reservedTextureUnits.addAll(var1);
+        reservedTextureUnits.add(4);
+        return reservedTextureUnits;
+    }
+}

--- a/src/main/resources/irisflw.mixins.flw.json
+++ b/src/main/resources/irisflw.mixins.flw.json
@@ -9,6 +9,7 @@
     "MixinLevelRender",
     "MixinModelUtil",
     "MixinProgramCompiler",
+    "MixinProgramSamplers",
     "MixinWorldProgram",
     "VertexCompilerAccessor"
   ],


### PR DESCRIPTION
Create hardcodes sampler '4' for its contraption shader, to render light volumes.

Fortunately, Iris has a pretty robust system in place to handle samplers used by other parts of the system.

This hooks the Iris sampler setup to inject the sampler '4', ensuring that Iris will not attempt to use that sampler for its own purposes.

Fixes #59 