### PR TITLE
made compatible with latest oculus v 1.6.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ minecraft {
         client {
             workingDirectory project.file('run')
 
+            //property 'mixin.env.remapRefMap', 'true'
+            // property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
+
+
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 
@@ -144,13 +148,21 @@ repositories {
         }
     }
 
-    maven {
+    /*maven {
         name "tterrag maven"
         url "https://maven.tterrag.com/"
+    }*/
+    maven {
+        name = 'tterrag maven'
+        url = 'https://maven.tterrag.com/'
     }
     maven {
         url "https://maven.tterrag.com/"
     }
+    maven {
+        url "https://maven.blamejared.com"
+    }
+
 }
 
 dependencies {
@@ -159,11 +171,16 @@ dependencies {
     // Apply Mixin AP
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 
-    implementation fg.deobf("maven.modrinth:rubidium:${sodium_version}")
+    //implementation fg.deobf("maven.modrinth:rubidium:${sodium_version}")
+
+    implementation fg.deobf("org.embeddedt:embeddium-${minecraft_version}:${embeddium_version}+mc${minecraft_version}")
 
     implementation fg.deobf("maven.modrinth:oculus:${iris_version}")
 
+    implementation fg.deobf("com.simibubi.create:create-${create_minecraft_version}:${create_version}:slim") { transitive = false }
     implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${flywheel_minecraft_version}:${flywheel_version}")
+    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
+    //implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${flywheel_minecraft_version}:${flywheel_version}")
 }
 
 // Example for how to get properties into the manifest for reading at runtime.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ mod_version=0.2.0
 maven_group=Leon
 archives_base_name=oculus-flywheel-compat
 
-forge_version=47.1.0
+forge_version=47.2.0
 platform=forge
 # Dependencies
 # Mappings
@@ -14,7 +14,16 @@ platform=forge
 qm_version=24
 # https://github.com/ParchmentMC/Parchment/wiki/Getting-Started
 parchment_version=2023.07.02
-flywheel_minecraft_version = 1.20
-flywheel_version=0.6.9-4
-sodium_version=0.6.5
-iris_version=1.20-1.6.4
+#flywheel_minecraft_version = 1.20
+#flywheel_version=0.6.9-4
+sodium_version=0.7.1
+iris_version=1.20.1-1.16.3
+
+
+create_minecraft_version = 1.20.1
+flywheel_minecraft_version = 1.20.1
+create_version = 0.5.1.e-22
+flywheel_version = 0.6.10-7
+registrate_version = MC1.20-1.3.3
+
+embeddium_version = 0.2.11-git.23aedfb


### PR DESCRIPTION
turns out the issues with latest oculus were due to misconfigured gradle files, this should fix it
do note that this mod now uses embeddium cause oculus doesnt like base rubidium.
didnt test for oculus 1.6.13a due to it being corrupt.
lemme know if theres any issues

Fixes #91 